### PR TITLE
Minor updates to configuration and deployment

### DIFF
--- a/config/jenkins/configuration-reload.sh
+++ b/config/jenkins/configuration-reload.sh
@@ -85,6 +85,7 @@ git -C ${JENKINS_HOME}/test-infra/ diff --name-only ${LOCAL} ${REMOTE} -- config
 
     # Pull in new commits
     git -C ${JENKINS_HOME}/test-infra/ clean -dfx
+    git -C ${JENKINS_HOME}/test-infra/ checkout -- config/jenkins
     git -C ${JENKINS_HOME}/test-infra/ reset --hard origin/${BRANCH}
 
     # Copy over new configuration to Jenkins

--- a/config/jenkins/deploy_jenkins.sh
+++ b/config/jenkins/deploy_jenkins.sh
@@ -322,7 +322,7 @@ install_jenkins_plugins () {
         # This creates a new pod and terminates the currently running pod, so plugins are reloaded.
         echo "Waiting for first pod to be ready to avoid conflicts..."
         kubectl wait --for=condition=ready pod -l app=jenkins-master --timeout=30m
-        kubectl patch deployment jenkins-master -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"date\":\"$(date +%s)\"}}}}}"
+        kubectl rollout restart deployment/jenkins-master
     fi
 }
 

--- a/config/jenkins/kubernetes/configuration-update.yml
+++ b/config/jenkins/kubernetes/configuration-update.yml
@@ -44,8 +44,9 @@ spec:
   schedule: '*/5 * * * *'
   jobTemplate:
     spec:
-      backoffLimit: 1
-      activeDeadlineSeconds: 600
+      backoffLimit: 0
+      # We don't want the script to end prematurely as that can leave the directory or configs in a bad state
+      activeDeadlineSeconds: 1800
       template:
         spec:
           serviceAccountName: configuration-update


### PR DESCRIPTION
- Prevent issues with leaving configuration patches in a bad state by extending timeout period and cleaning up the git directory
- Use rollout restarts instead of patching deployments to restart the Jenkins pod