### PR TITLE
Use advanced image to support VM agent vnet/snet

### DIFF
--- a/config/jenkins/configuration/clouds.yml
+++ b/config/jenkins/configuration/clouds.yml
@@ -234,9 +234,16 @@ jenkins:
         ephemeralOSDisk: false
         executeInitScriptAsRoot: true
         existingStorageAccountName: ""
-        imageTopLevelType: "basic"
-        installDocker: true
-        installGit: true
+        imageReference:
+          galleryImageDefinition: "ubuntu-18.04"
+          galleryImageVersion: "latest"
+          galleryName: "<AZURE_VM_GALLERY_NAME>"
+          galleryResourceGroup: "<AZURE_VM_GALLERY_RESOURCE_GROUP>"
+          gallerySubscriptionId: "<AZURE_VM_GALLERY_SUBSCRIPTION_ID>"
+        imageTopLevelType: "advanced"
+        initScript: "gpasswd -a oeadmin docker \nchmod g+rw /var/run/docker.sock"
+        installDocker: false
+        installGit: false
         installMaven: false
         javaPath: "java"
         labels: "OverWatch"
@@ -490,9 +497,16 @@ jenkins:
         ephemeralOSDisk: false
         executeInitScriptAsRoot: true
         existingStorageAccountName: ""
-        imageTopLevelType: "basic"
-        installDocker: true
-        installGit: true
+        imageReference:
+          galleryImageDefinition: "ubuntu-18.04"
+          galleryImageVersion: "latest"
+          galleryName: "<AZURE_VM_GALLERY_NAME>"
+          galleryResourceGroup: "<AZURE_VM_GALLERY_RESOURCE_GROUP>"
+          gallerySubscriptionId: "<AZURE_VM_GALLERY_SUBSCRIPTION_ID>"
+        imageTopLevelType: "advanced"
+        initScript: "gpasswd -a oeadmin docker \nchmod g+rw /var/run/docker.sock"
+        installDocker: false
+        installGit: false
         installMaven: false
         javaPath: "java"
         labels: "OverWatch"
@@ -746,9 +760,16 @@ jenkins:
         ephemeralOSDisk: false
         executeInitScriptAsRoot: true
         existingStorageAccountName: ""
-        imageTopLevelType: "basic"
-        installDocker: true
-        installGit: true
+        imageReference:
+          galleryImageDefinition: "ubuntu-18.04"
+          galleryImageVersion: "latest"
+          galleryName: "<AZURE_VM_GALLERY_NAME>"
+          galleryResourceGroup: "<AZURE_VM_GALLERY_RESOURCE_GROUP>"
+          gallerySubscriptionId: "<AZURE_VM_GALLERY_SUBSCRIPTION_ID>"
+        imageTopLevelType: "advanced"
+        initScript: "gpasswd -a oeadmin docker \nchmod g+rw /var/run/docker.sock"
+        installDocker: false
+        installGit: false
         installMaven: false
         javaPath: "java"
         labels: "OverWatch"


### PR DESCRIPTION
Azure VM Agents continued to request Azure deployments for Overwatch agents that includes a virtual network, but it fails as there is already an existing virtual network that is peered. This causes the deployment to fail. It seems the basic image settings for Azure VM Agents plugin does not enable the specification of a predefined virtual network and subnet, so we need to switch to an advanced image setting.

Signed-off-by: Chris Yan <chrisyan@microsoft.com>