### PR TITLE
HPA nginx controllers on dedicated nodes

### DIFF
--- a/config/jenkins/kubernetes/ingress-nginx-values.yml
+++ b/config/jenkins/kubernetes/ingress-nginx-values.yml
@@ -1,0 +1,26 @@
+---
+controller:
+  stats:
+    enabled: true
+  metrics:
+    enabled: true
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 85
+  nodeSelector:
+    role: ingress
+  podLabels:
+    app: ingress-nginx
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - ingress-nginx
+        topologyKey: "kubernetes.io/hostname"

--- a/config/jenkins/kubernetes/jenkins-ingress.yml
+++ b/config/jenkins/kubernetes/jenkins-ingress.yml
@@ -34,6 +34,9 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: '360s'
     nginx.ingress.kubernetes.io/proxy-read-timeout: '360s'
     nginx.ingress.kubernetes.io/proxy-ssl-protocols: 'TLSv1.2 TLSv1.3'
+    nginx.ingress.kubernetes.io/client_max_body_size: '5M'
+    nginx.ingress.kubernetes.io/client_body_buffer_size: '5M'
+    nginx.ingress.kubernetes.io/proxy_buffers: '8 5M'
     cert-manager.io/cluster-issuer: "letsencrypt-production"
 spec:
   tls:
@@ -47,4 +50,4 @@ spec:
       - path: /
         backend:
           serviceName: jenkins-master-nodeport
-          servicePort: 8080
+          servicePort: 80


### PR DESCRIPTION
This allows for horizontal pod autoscaling of nginx-ingress controller pods on dedicated compute-optimized nodes, which is used to better handle bursts of job submissions and queries via Jenkins API.

Signed-off-by: Chris Yan <chrisyan@microsoft.com>