### PR TITLE
Change Jenkins files to light weight checkout

### DIFF
--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Rhel8BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Rhel8BuildClang-8.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/oeedger8r-cpp/jenkins/RhelBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1604BuildClang-7.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/oeedger8r-cpp/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1604BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1604BuildClang-8.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/oeedger8r-cpp/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1804BuildClang-7.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/oeedger8r-cpp/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1804BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1804BuildClang-8.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/oeedger8r-cpp/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Windows2016Build.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Windows2016Build.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/oeedger8r-cpp/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Windows2019Build.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/oeedger8r-cpp/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave-curl/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave-curl/Ubuntu1604BuildClang-7.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave-curl/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave-curl/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave-curl/Ubuntu1804BuildClang-7.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave-curl/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave-mbedtls/Rhel8BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/openenclave-mbedtls/Rhel8BuildClang-8.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave-mbedtls/jenkins/RhelBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave-mbedtls/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave-mbedtls/Ubuntu1604BuildClang-7.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave-mbedtls/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave-mbedtls/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave-mbedtls/Ubuntu1804BuildClang-7.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave-mbedtls/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave-mbedtls/Windows2016Build.yml
+++ b/config/jenkins/configuration/jobs/openenclave-mbedtls/Windows2016Build.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave-mbedtls/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave-mbedtls/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/openenclave-mbedtls/Windows2019Build.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave-mbedtls/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/AArch64GNU1604Debug.yml
+++ b/config/jenkins/configuration/jobs/openenclave/AArch64GNU1604Debug.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/ArchLinux.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/AArch64GNU1604Release.yml
+++ b/config/jenkins/configuration/jobs/openenclave/AArch64GNU1604Release.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/ArchLinux.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/AArch64GNU1804Debug.yml
+++ b/config/jenkins/configuration/jobs/openenclave/AArch64GNU1804Debug.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/ArchLinux.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/AArch64GNU1804Release.yml
+++ b/config/jenkins/configuration/jobs/openenclave/AArch64GNU1804Release.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/ArchLinux.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/HostVerifyDeb16042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/HostVerifyDeb16042019.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/HostVerify.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/HostVerifyDeb18042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/HostVerifyDeb18042019.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/HostVerify.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/HostVerifyRel16042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/HostVerifyRel16042019.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/HostVerify.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/HostVerifyRel18042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/HostVerifyRel18042019.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/HostVerify.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/LinuxElfDeb16042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/LinuxElfDeb16042019.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/LinuxElfBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/LinuxElfDeb18042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/LinuxElfDeb18042019.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/LinuxElfBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/LinuxElfRel16042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/LinuxElfRel16042019.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/LinuxElfBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/LinuxElfRel18042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/LinuxElfRel18042019.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/LinuxElfBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/RhelBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8Snmalloc.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/RhelBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8SnmallocE2E.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/RhelBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/RhelBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8Snmalloc.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/RhelBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8SnmallocE2E.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/RhelBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7Snmalloc.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7SnmallocE2E.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7Snmalloc.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7SnmallocE2E.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7Snmalloc.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7SnmallocE2E.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7Snmalloc.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7SnmallocE2E.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7Snmalloc.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7SnmallocE2E.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7Snmalloc.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7SnmallocE2E.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Win2016DebSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016DebSnmallocE2E.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Win2016Debug.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016Debug.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Win2016DebugSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016DebugSnmalloc.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Win2016RelSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016RelSnmalloc.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Win2016RelSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016RelSnmallocE2E.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Win2016Release.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016Release.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Win2019Debug.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019Debug.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Win2019DebugSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019DebugSnmalloc.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Win2019DebugSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019DebugSnmallocE2E.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Win2019RelSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019RelSnmalloc.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Win2019RelSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019RelSnmallocE2E.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/openenclave/Win2019Release.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019Release.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra-images/Ubuntu1604Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra-images/Ubuntu1604Build.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/test-infra-images/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra-images/Ubuntu1804Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra-images/Ubuntu1804Build.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/test-infra-images/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra-images/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra-images/Windows2019Build.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/test-infra-images/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Rhel8BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Rhel8BuildClang-8.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/oeedger8r-cpp/jenkins/RhelBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1604BuildClang-7.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/oeedger8r-cpp/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1604BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1604BuildClang-8.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/oeedger8r-cpp/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1804BuildClang-7.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/oeedger8r-cpp/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1804BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1804BuildClang-8.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/oeedger8r-cpp/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Windows2016Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Windows2016Build.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/oeedger8r-cpp/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Windows2019Build.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/oeedger8r-cpp/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-curl/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-curl/Ubuntu1604BuildClang-7.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave-curl/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-curl/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-curl/Ubuntu1804BuildClang-7.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave-curl/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Rhel8BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Rhel8BuildClang-8.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave-mbedtls/jenkins/RhelBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Ubuntu1604BuildClang-7.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave-mbedtls/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Ubuntu1804BuildClang-7.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave-mbedtls/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Windows2016Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Windows2016Build.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave-mbedtls/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Windows2019Build.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave-mbedtls/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1604Debug.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1604Debug.yml
@@ -102,6 +102,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/ArchLinux.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1604Release.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1604Release.yml
@@ -102,6 +102,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/ArchLinux.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1804Debug.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1804Debug.yml
@@ -102,6 +102,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/ArchLinux.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1804Release.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1804Release.yml
@@ -102,6 +102,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/ArchLinux.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyDeb16042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyDeb16042019.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/HostVerify.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyDeb18042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyDeb18042019.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/HostVerify.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyRel16042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyRel16042019.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/HostVerify.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyRel18042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyRel18042019.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/HostVerify.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfDeb16042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfDeb16042019.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/LinuxElfBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfDeb18042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfDeb18042019.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/LinuxElfBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfRel16042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfRel16042019.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/LinuxElfBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfRel18042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfRel18042019.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/LinuxElfBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/RhelBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8Snmalloc.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/RhelBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8SnmallocE2E.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/RhelBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/RhelBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8Snmalloc.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/RhelBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8SnmallocE2E.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/RhelBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7Snmalloc.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7SnmallocE2E.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7Snmalloc.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7SnmallocE2E.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7Snmalloc.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7SnmallocE2E.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7Snmalloc.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7SnmallocE2E.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7Snmalloc.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7SnmallocE2E.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7Snmalloc.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7SnmallocE2E.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016DebSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016DebSnmallocE2E.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016Debug.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016Debug.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016DebugSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016DebugSnmalloc.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016RelSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016RelSnmalloc.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016RelSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016RelSnmallocE2E.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016Release.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016Release.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019Debug.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019Debug.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019DebugSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019DebugSnmalloc.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019DebugSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019DebugSnmallocE2E.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019RelSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019RelSnmalloc.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019RelSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019RelSnmallocE2E.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019Release.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019Release.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/openenclave/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/test-infra-images/Ubuntu1604Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/test-infra-images/Ubuntu1604Build.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/test-infra-images/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/test-infra-images/Ubuntu1804Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/test-infra-images/Ubuntu1804Build.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/test-infra-images/jenkins/UbuntuBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jenkins/configuration/jobs/test-infra/test-infra-images/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/test-infra-images/Windows2019Build.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/test-infra-images/jenkins/WindowsBuild.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jobs/templates/jenkins/jobs/ArchLinux.yml
+++ b/config/jobs/templates/jenkins/jobs/ArchLinux.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/${repo}/jenkins/${jobmap[$pipeline]}.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jobs/templates/jenkins/jobs/HostVerify.yml
+++ b/config/jobs/templates/jenkins/jobs/HostVerify.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/${repo}/jenkins/${jobmap[$pipeline]}.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jobs/templates/jenkins/jobs/LinuxElfBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/LinuxElfBuild.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/${repo}/jenkins/${jobmap[$pipeline]}.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jobs/templates/jenkins/jobs/RhelBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/RhelBuild.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/${repo}/jenkins/${jobmap[$pipeline]}.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jobs/templates/jenkins/jobs/UbuntuBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/UbuntuBuild.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/${repo}/jenkins/${jobmap[$pipeline]}.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jobs/templates/jenkins/jobs/WindowsBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/WindowsBuild.yml
@@ -99,6 +99,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/${repo}/jenkins/${jobmap[$pipeline]}.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jobs/templates/jenkins/jobs/test-infra/ArchLinux.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/ArchLinux.yml
@@ -102,6 +102,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/${repo}/jenkins/${jobmap[$pipeline]}.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jobs/templates/jenkins/jobs/test-infra/HostVerify.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/HostVerify.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/${repo}/jenkins/${jobmap[$pipeline]}.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jobs/templates/jenkins/jobs/test-infra/LinuxElfBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/LinuxElfBuild.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/${repo}/jenkins/${jobmap[$pipeline]}.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jobs/templates/jenkins/jobs/test-infra/RhelBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/RhelBuild.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/${repo}/jenkins/${jobmap[$pipeline]}.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jobs/templates/jenkins/jobs/test-infra/UbuntuBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/UbuntuBuild.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/${repo}/jenkins/${jobmap[$pipeline]}.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)

--- a/config/jobs/templates/jenkins/jobs/test-infra/WindowsBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/WindowsBuild.yml
@@ -103,6 +103,7 @@ jobs:
                         }
                     }
                     scriptPath("config/jobs/${repo}/jenkins/${jobmap[$pipeline]}.Jenkinsfile")
+                    lightweight(true)
                 }
             }
             disabled(false)


### PR DESCRIPTION
This PR changes all Jenkins files to use lightweight checkout reducing the string on the master node during job initialization

Signed-off-by: brmclare <brmclare@microsoft.com>