### PR TITLE
Enable concu

### DIFF
--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Rhel8BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Rhel8BuildClang-8.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Rhel8BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Rhel8BuildClang-8.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1604BuildClang-7.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1604BuildClang-7.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1604BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1604BuildClang-8.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1604BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1604BuildClang-8.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1804BuildClang-7.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1804BuildClang-7.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1804BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1804BuildClang-8.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1804BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Ubuntu1804BuildClang-8.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Windows2016Build.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Windows2016Build.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Windows2016Build.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Windows2016Build.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Windows2019Build.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/oeedger8r-cpp/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/oeedger8r-cpp/Windows2019Build.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave-curl/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave-curl/Ubuntu1604BuildClang-7.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave-curl/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave-curl/Ubuntu1604BuildClang-7.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave-curl/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave-curl/Ubuntu1804BuildClang-7.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave-curl/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave-curl/Ubuntu1804BuildClang-7.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave-mbedtls/Rhel8BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/openenclave-mbedtls/Rhel8BuildClang-8.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave-mbedtls/Rhel8BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/openenclave-mbedtls/Rhel8BuildClang-8.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave-mbedtls/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave-mbedtls/Ubuntu1604BuildClang-7.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave-mbedtls/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave-mbedtls/Ubuntu1604BuildClang-7.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave-mbedtls/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave-mbedtls/Ubuntu1804BuildClang-7.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave-mbedtls/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave-mbedtls/Ubuntu1804BuildClang-7.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave-mbedtls/Windows2016Build.yml
+++ b/config/jenkins/configuration/jobs/openenclave-mbedtls/Windows2016Build.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave-mbedtls/Windows2016Build.yml
+++ b/config/jenkins/configuration/jobs/openenclave-mbedtls/Windows2016Build.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave-mbedtls/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/openenclave-mbedtls/Windows2019Build.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave-mbedtls/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/openenclave-mbedtls/Windows2019Build.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/AArch64GNU1604Debug.yml
+++ b/config/jenkins/configuration/jobs/openenclave/AArch64GNU1604Debug.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/AArch64GNU1604Debug.yml
+++ b/config/jenkins/configuration/jobs/openenclave/AArch64GNU1604Debug.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/AArch64GNU1604Release.yml
+++ b/config/jenkins/configuration/jobs/openenclave/AArch64GNU1604Release.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/AArch64GNU1604Release.yml
+++ b/config/jenkins/configuration/jobs/openenclave/AArch64GNU1604Release.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/AArch64GNU1804Debug.yml
+++ b/config/jenkins/configuration/jobs/openenclave/AArch64GNU1804Debug.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/AArch64GNU1804Debug.yml
+++ b/config/jenkins/configuration/jobs/openenclave/AArch64GNU1804Debug.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/AArch64GNU1804Release.yml
+++ b/config/jenkins/configuration/jobs/openenclave/AArch64GNU1804Release.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/AArch64GNU1804Release.yml
+++ b/config/jenkins/configuration/jobs/openenclave/AArch64GNU1804Release.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/HostVerifyDeb16042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/HostVerifyDeb16042019.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/HostVerifyDeb16042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/HostVerifyDeb16042019.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/HostVerifyDeb18042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/HostVerifyDeb18042019.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/HostVerifyDeb18042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/HostVerifyDeb18042019.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/HostVerifyRel16042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/HostVerifyRel16042019.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/HostVerifyRel16042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/HostVerifyRel16042019.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/HostVerifyRel18042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/HostVerifyRel18042019.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/HostVerifyRel18042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/HostVerifyRel18042019.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/LinuxElfDeb16042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/LinuxElfDeb16042019.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/LinuxElfDeb16042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/LinuxElfDeb16042019.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/LinuxElfDeb18042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/LinuxElfDeb18042019.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/LinuxElfDeb18042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/LinuxElfDeb18042019.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/LinuxElfRel16042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/LinuxElfRel16042019.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/LinuxElfRel16042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/LinuxElfRel16042019.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/LinuxElfRel18042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/LinuxElfRel18042019.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/LinuxElfRel18042019.yml
+++ b/config/jenkins/configuration/jobs/openenclave/LinuxElfRel18042019.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8Snmalloc.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8Snmalloc.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8SnmallocE2E.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8DebugClang-8SnmallocE2E.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8Snmalloc.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8Snmalloc.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8SnmallocE2E.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Rhel8ReleaseClang-8SnmallocE2E.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7Snmalloc.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7Snmalloc.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7SnmallocE2E.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604DebugClang-7SnmallocE2E.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7Snmalloc.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7Snmalloc.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7SnmallocE2E.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604RelWithDebInfoClang-7SnmallocE2E.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7Snmalloc.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7Snmalloc.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7SnmallocE2E.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1604ReleaseClang-7SnmallocE2E.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7Snmalloc.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7Snmalloc.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7SnmallocE2E.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804DebugClang-7SnmallocE2E.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7Snmalloc.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7Snmalloc.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7SnmallocE2E.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804RelWithDebInfoClang-7SnmallocE2E.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7Snmalloc.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7Snmalloc.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7SnmallocE2E.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Ubuntu1804ReleaseClang-7SnmallocE2E.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2016DebSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016DebSnmallocE2E.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2016DebSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016DebSnmallocE2E.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2016Debug.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016Debug.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2016Debug.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016Debug.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2016DebugSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016DebugSnmalloc.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2016DebugSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016DebugSnmalloc.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2016RelSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016RelSnmalloc.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2016RelSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016RelSnmalloc.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2016RelSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016RelSnmallocE2E.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2016RelSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016RelSnmallocE2E.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2016Release.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016Release.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2016Release.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2016Release.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2019Debug.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019Debug.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2019Debug.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019Debug.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2019DebugSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019DebugSnmalloc.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2019DebugSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019DebugSnmalloc.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2019DebugSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019DebugSnmallocE2E.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2019DebugSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019DebugSnmallocE2E.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2019RelSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019RelSnmalloc.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2019RelSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019RelSnmalloc.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2019RelSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019RelSnmallocE2E.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2019RelSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019RelSnmallocE2E.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2019Release.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019Release.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/openenclave/Win2019Release.yml
+++ b/config/jenkins/configuration/jobs/openenclave/Win2019Release.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra-images/Ubuntu1604Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra-images/Ubuntu1604Build.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra-images/Ubuntu1604Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra-images/Ubuntu1604Build.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra-images/Ubuntu1804Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra-images/Ubuntu1804Build.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra-images/Ubuntu1804Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra-images/Ubuntu1804Build.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra-images/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra-images/Windows2019Build.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra-images/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra-images/Windows2019Build.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Rhel8BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Rhel8BuildClang-8.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Rhel8BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Rhel8BuildClang-8.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1604BuildClang-7.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1604BuildClang-7.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1604BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1604BuildClang-8.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1604BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1604BuildClang-8.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1804BuildClang-7.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1804BuildClang-7.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1804BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1804BuildClang-8.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1804BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Ubuntu1804BuildClang-8.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Windows2016Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Windows2016Build.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Windows2016Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Windows2016Build.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Windows2019Build.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/oeedger8r-cpp/Windows2019Build.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-curl/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-curl/Ubuntu1604BuildClang-7.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-curl/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-curl/Ubuntu1604BuildClang-7.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-curl/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-curl/Ubuntu1804BuildClang-7.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-curl/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-curl/Ubuntu1804BuildClang-7.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Rhel8BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Rhel8BuildClang-8.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Rhel8BuildClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Rhel8BuildClang-8.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Ubuntu1604BuildClang-7.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Ubuntu1604BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Ubuntu1604BuildClang-7.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Ubuntu1804BuildClang-7.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Ubuntu1804BuildClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Ubuntu1804BuildClang-7.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Windows2016Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Windows2016Build.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Windows2016Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Windows2016Build.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Windows2019Build.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave-mbedtls/Windows2019Build.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1604Debug.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1604Debug.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1604Debug.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1604Debug.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1604Release.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1604Release.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1604Release.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1604Release.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1804Debug.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1804Debug.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1804Debug.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1804Debug.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1804Release.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1804Release.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1804Release.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/AArch64GNU1804Release.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyDeb16042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyDeb16042019.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyDeb16042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyDeb16042019.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyDeb18042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyDeb18042019.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyDeb18042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyDeb18042019.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyRel16042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyRel16042019.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyRel16042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyRel16042019.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyRel18042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyRel18042019.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyRel18042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/HostVerifyRel18042019.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfDeb16042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfDeb16042019.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfDeb16042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfDeb16042019.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfDeb18042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfDeb18042019.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfDeb18042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfDeb18042019.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfRel16042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfRel16042019.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfRel16042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfRel16042019.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfRel18042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfRel18042019.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfRel18042019.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/LinuxElfRel18042019.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8Snmalloc.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8Snmalloc.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8SnmallocE2E.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8DebugClang-8SnmallocE2E.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8Snmalloc.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8Snmalloc.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8SnmallocE2E.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Rhel8ReleaseClang-8SnmallocE2E.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7Snmalloc.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7Snmalloc.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7SnmallocE2E.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604DebugClang-7SnmallocE2E.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7Snmalloc.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7Snmalloc.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7SnmallocE2E.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604RelWithDebInfoClang-7SnmallocE2E.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7Snmalloc.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7Snmalloc.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7SnmallocE2E.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1604ReleaseClang-7SnmallocE2E.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7Snmalloc.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7Snmalloc.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7SnmallocE2E.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804DebugClang-7SnmallocE2E.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7Snmalloc.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7Snmalloc.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7SnmallocE2E.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804RelWithDebInfoClang-7SnmallocE2E.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7Snmalloc.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7Snmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7Snmalloc.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7SnmallocE2E.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7SnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Ubuntu1804ReleaseClang-7SnmallocE2E.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016DebSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016DebSnmallocE2E.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016DebSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016DebSnmallocE2E.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016Debug.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016Debug.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016Debug.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016Debug.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016DebugSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016DebugSnmalloc.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016DebugSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016DebugSnmalloc.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016RelSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016RelSnmalloc.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016RelSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016RelSnmalloc.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016RelSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016RelSnmallocE2E.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016RelSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016RelSnmallocE2E.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016Release.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016Release.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016Release.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2016Release.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019Debug.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019Debug.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019Debug.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019Debug.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019DebugSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019DebugSnmalloc.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019DebugSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019DebugSnmalloc.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019DebugSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019DebugSnmallocE2E.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019DebugSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019DebugSnmallocE2E.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019RelSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019RelSnmalloc.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019RelSnmalloc.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019RelSnmalloc.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019RelSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019RelSnmallocE2E.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019RelSnmallocE2E.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019RelSnmallocE2E.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019Release.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019Release.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019Release.yml
+++ b/config/jenkins/configuration/jobs/test-infra/openenclave/Win2019Release.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/test-infra-images/Ubuntu1604Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/test-infra-images/Ubuntu1604Build.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/test-infra-images/Ubuntu1604Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/test-infra-images/Ubuntu1604Build.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/test-infra-images/Ubuntu1804Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/test-infra-images/Ubuntu1804Build.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/test-infra-images/Ubuntu1804Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/test-infra-images/Ubuntu1804Build.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/test-infra-images/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/test-infra-images/Windows2019Build.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jenkins/configuration/jobs/test-infra/test-infra-images/Windows2019Build.yml
+++ b/config/jenkins/configuration/jobs/test-infra/test-infra-images/Windows2019Build.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/ArchLinux.yml
+++ b/config/jobs/templates/jenkins/jobs/ArchLinux.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/ArchLinux.yml
+++ b/config/jobs/templates/jenkins/jobs/ArchLinux.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/HostVerify.yml
+++ b/config/jobs/templates/jenkins/jobs/HostVerify.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/HostVerify.yml
+++ b/config/jobs/templates/jenkins/jobs/HostVerify.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/LinuxElfBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/LinuxElfBuild.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/LinuxElfBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/LinuxElfBuild.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/RhelBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/RhelBuild.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/RhelBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/RhelBuild.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/UbuntuBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/UbuntuBuild.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/UbuntuBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/UbuntuBuild.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/WindowsBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/WindowsBuild.yml
@@ -8,7 +8,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/WindowsBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/WindowsBuild.yml
@@ -8,7 +8,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/test-infra/ArchLinux.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/ArchLinux.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/test-infra/ArchLinux.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/ArchLinux.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/test-infra/HostVerify.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/HostVerify.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/test-infra/HostVerify.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/HostVerify.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/test-infra/LinuxElfBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/LinuxElfBuild.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/test-infra/LinuxElfBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/LinuxElfBuild.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/test-infra/RhelBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/RhelBuild.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/test-infra/RhelBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/RhelBuild.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/test-infra/UbuntuBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/UbuntuBuild.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/test-infra/UbuntuBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/UbuntuBuild.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/test-infra/WindowsBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/WindowsBuild.yml
@@ -11,7 +11,7 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            concurrentBuild(false)
+            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")

--- a/config/jobs/templates/jenkins/jobs/test-infra/WindowsBuild.yml
+++ b/config/jobs/templates/jenkins/jobs/test-infra/WindowsBuild.yml
@@ -11,7 +11,6 @@ jobs:
             quietPeriod(0)
             description()
             keepDependencies(false)
-            disableConcurrentBuilds()
             parameters {
                 stringParam {
                     name("OE_TEST_INFRA_PULL_NUMBER")


### PR DESCRIPTION
This PR enables concurrent builds on the Jenkins job DSL's by everything the prior commits disabling.