### PR TITLE
Mount war dir to ephemeral storage

### DIFF
--- a/config/jenkins/kubernetes/jenkins-master-deployment.yml
+++ b/config/jenkins/kubernetes/jenkins-master-deployment.yml
@@ -70,8 +70,10 @@ spec:
         - name: CASC_JENKINS_CONFIG
           value: /var/jenkins_home/configuration/
         volumeMounts:
-        - name: volume
+        - name: jenkins-home
           mountPath: "/var/jenkins_home"
+        - name: jenkins-war
+          mountPath: "/var/jenkins_home/war"
         livenessProbe:
           httpGet:
             path: /login
@@ -95,6 +97,8 @@ spec:
             cpu: "8"
             memory: 30Gi
       volumes:
-      - name: volume
+      - name: jenkins-home
         persistentVolumeClaim:
           claimName: jenkins-master-volume
+      - name: jenkins-war
++       emptyDir: {}


### PR DESCRIPTION
  This prevents an issue where containers with a new Jenkins
  image version would not start due to conflicting files in the
  war directory.

Signed-off-by: Chris Yan <chrisyan@microsoft.com>