### PR TITLE
add non sgx linux agents

### DIFF
--- a/config/jenkins/configuration/clouds.yml
+++ b/config/jenkins/configuration/clouds.yml
@@ -62,6 +62,47 @@ jenkins:
         executeInitScriptAsRoot: true
         existingStorageAccountName: ""
         imageReference:
+          galleryImageDefinition: "ubuntu-18.04"
+          galleryImageVersion: "2020.12.03"
+          galleryName: "<AZURE_VM_GALLERY_NAME>"
+          galleryResourceGroup: "<AZURE_VM_GALLERY_RESOURCE_GROUP>"
+          gallerySubscriptionId: "<AZURE_VM_GALLERY_SUBSCRIPTION_ID>"
+        imageTopLevelType: "advanced"
+        initScript: "gpasswd -a oeadmin docker \nchmod g+rw /var/run/docker.sock"
+        installDocker: false
+        installGit: false
+        installMaven: false
+        javaPath: "java"
+        labels: "NonSGX-Ubuntu-1804"
+        location: "UK South"
+        noOfParallelJobs: 4
+        osDiskSize: 256
+        osType: "Linux"
+        preInstallSsh: true
+        retentionStrategy:
+          azureVMCloudRetentionStrategy:
+            idleTerminationMinutes: 60
+        shutdownOnIdle: false
+        storageAccountNameReferenceType: "new"
+        storageAccountType: "Standard_LRS"
+        subnetName: "jenkinsarm-snet"
+        templateDisabled: false
+        templateName: "nonsgxubuntu1804"
+        usageMode: "Only build jobs with label expressions matching this node"
+        usePrivateIP: true
+        virtualMachineSize: "Standard_F8s_v2"
+        virtualNetworkName: "jenkinsarm-vnet"
+      - agentLaunchMethod: "SSH"
+        builtInImage: "Ubuntu 16.04 LTS"
+        credentialsId: "JenkinsOEAdminAgents"
+        diskType: "managed"
+        doNotUseMachineIfInitFails: true
+        enableMSI: false
+        enableUAMI: false
+        ephemeralOSDisk: false
+        executeInitScriptAsRoot: true
+        existingStorageAccountName: ""
+        imageReference:
           galleryImageDefinition: "ubuntu-16.04"
           galleryImageVersion: "latest"
           galleryName: "<AZURE_VM_GALLERY_NAME>"
@@ -368,6 +409,47 @@ jenkins:
         executeInitScriptAsRoot: true
         existingStorageAccountName: ""
         imageReference:
+          galleryImageDefinition: "ubuntu-18.04"
+          galleryImageVersion: "2020.12.03"
+          galleryName: "<AZURE_VM_GALLERY_NAME>"
+          galleryResourceGroup: "<AZURE_VM_GALLERY_RESOURCE_GROUP>"
+          gallerySubscriptionId: "<AZURE_VM_GALLERY_SUBSCRIPTION_ID>"
+        imageTopLevelType: "advanced"
+        initScript: "gpasswd -a oeadmin docker \nchmod g+rw /var/run/docker.sock"
+        installDocker: false
+        installGit: false
+        installMaven: false
+        javaPath: "java"
+        labels: "NonSGX-Ubuntu-1804"
+        location: "East US"
+        noOfParallelJobs: 4
+        osDiskSize: 256
+        osType: "Linux"
+        preInstallSsh: true
+        retentionStrategy:
+          azureVMCloudRetentionStrategy:
+            idleTerminationMinutes: 60
+        shutdownOnIdle: false
+        storageAccountNameReferenceType: "new"
+        storageAccountType: "Standard_LRS"
+        subnetName: "jenkinsarm-snet"
+        templateDisabled: false
+        templateName: "nonsgxubuntu1804"
+        usageMode: "Only build jobs with label expressions matching this node"
+        usePrivateIP: true
+        virtualMachineSize: "Standard_F8s_v2"
+        virtualNetworkName: "jenkinsarm-vnet"
+      - agentLaunchMethod: "SSH"
+        builtInImage: "Ubuntu 16.04 LTS"
+        credentialsId: "JenkinsOEAdminAgents"
+        diskType: "managed"
+        doNotUseMachineIfInitFails: true
+        enableMSI: false
+        enableUAMI: false
+        ephemeralOSDisk: false
+        executeInitScriptAsRoot: true
+        existingStorageAccountName: ""
+        imageReference:
           galleryImageDefinition: "ubuntu-16.04"
           galleryImageVersion: "2020.12.03"
           galleryName: "<AZURE_VM_GALLERY_NAME>"
@@ -619,6 +701,47 @@ jenkins:
         usageMode: "Only build jobs with label expressions matching this node"
         usePrivateIP: true
         virtualMachineSize: "Standard_DC2s_v2"
+        virtualNetworkName: "jenkinsarm-vnet"
+      - agentLaunchMethod: "SSH"
+        builtInImage: "Ubuntu 16.04 LTS"
+        credentialsId: "JenkinsOEAdminAgents"
+        diskType: "managed"
+        doNotUseMachineIfInitFails: true
+        enableMSI: false
+        enableUAMI: false
+        ephemeralOSDisk: false
+        executeInitScriptAsRoot: true
+        existingStorageAccountName: ""
+        imageReference:
+          galleryImageDefinition: "ubuntu-18.04"
+          galleryImageVersion: "2020.12.03"
+          galleryName: "<AZURE_VM_GALLERY_NAME>"
+          galleryResourceGroup: "<AZURE_VM_GALLERY_RESOURCE_GROUP>"
+          gallerySubscriptionId: "<AZURE_VM_GALLERY_SUBSCRIPTION_ID>"
+        imageTopLevelType: "advanced"
+        initScript: "gpasswd -a oeadmin docker \nchmod g+rw /var/run/docker.sock"
+        installDocker: false
+        installGit: false
+        installMaven: false
+        javaPath: "java"
+        labels: "NonSGX-Ubuntu-1804"
+        location: "West US 2"
+        noOfParallelJobs: 4
+        osDiskSize: 256
+        osType: "Linux"
+        preInstallSsh: true
+        retentionStrategy:
+          azureVMCloudRetentionStrategy:
+            idleTerminationMinutes: 60
+        shutdownOnIdle: false
+        storageAccountNameReferenceType: "new"
+        storageAccountType: "Standard_LRS"
+        subnetName: "jenkinsarm-snet"
+        templateDisabled: false
+        templateName: "nonsgxubuntu1804"
+        usageMode: "Only build jobs with label expressions matching this node"
+        usePrivateIP: true
+        virtualMachineSize: "Standard_F8s_v2"
         virtualNetworkName: "jenkinsarm-vnet"
       - agentLaunchMethod: "SSH"
         builtInImage: "Ubuntu 16.04 LTS"


### PR DESCRIPTION
Add linux non-sgx skus for host validation and Linux elf. Reuse acc images as only hardware capability matters.

Signed-off-by: brmclare <brmclare@microsoft.com>